### PR TITLE
JUN WEEK2 : MooTube (Silver) 

### DIFF
--- a/Baekjoon/MooTube(Silver)_15591.py
+++ b/Baekjoon/MooTube(Silver)_15591.py
@@ -1,0 +1,56 @@
+'''
+1. MOOTube에 1부터 N까지 번호가 붙여진 N개의 동영상이 존재.
+2. 두 둉영상이 서로 얼마나 가까운지를 측정하는 단위 "USADO"
+    2-1. 각 영상은 정점으로 나타냄
+    2-2. 각 영상은 다른 영상으로 가는 경로가 반드시 하나는 존재
+    2-3. 임의의 두 쌍 사이의 동영상의 USADO를 그 경로의 모든 연결들의 USADO 중 최소값으로 함.
+4. 값 K를 정해서, USADO가 K이상인 모든 동영상이 추천되고, K가 입력되었을 때의 추천될 영상의 개수를 구하기
+'''
+global n
+
+
+def input_func():
+    global n
+    n, q = map(int, input().split())
+    usado = [[0 for _ in range(n)] for _ in range(n)]
+
+    for _ in range(n - 1):
+        input_p, input_q, input_r = map(int, input().split())
+        usado[input_p - 1][input_q - 1] = input_r
+        usado[input_q - 1][input_p - 1] = input_r
+
+    questions = []
+    for _ in range(q):
+        questions.append(list(map(int, input().split())))
+    return usado, questions
+
+
+def get_minimum_usado(usado, i, j):
+    for k in range(n):
+        if usado[i][k] > 0 and usado[k][j] > 0:
+            min_usado = min(usado[i][k], usado[k][j])
+            usado[i][j] = min_usado
+            usado[j][i] = min_usado
+
+
+def update_usado(usado, row_index):
+    # usado값이 정해지지 않은 값에 대해서 usado를 구함
+    for j in range(n):
+        if row_index == j:
+            continue
+        if usado[row_index][j] == 0:
+            get_minimum_usado(usado, row_index, j)
+
+
+def main():
+    usado, questions = input_func()
+    for k, v in questions:
+        update_usado(usado, v)
+        print(f"k: {k}, v : {v}")
+        print(usado)
+        cur_num_usado = usado[v - 1]
+        print(sum(1 for num in cur_num_usado if num >= k))
+
+
+if __name__ == "__main__":
+    main()

--- a/Baekjoon/MooTube(Silver)_15591.py
+++ b/Baekjoon/MooTube(Silver)_15591.py
@@ -1,23 +1,17 @@
-'''
-1. MOOTube에 1부터 N까지 번호가 붙여진 N개의 동영상이 존재.
-2. 두 둉영상이 서로 얼마나 가까운지를 측정하는 단위 "USADO"
-    2-1. 각 영상은 정점으로 나타냄
-    2-2. 각 영상은 다른 영상으로 가는 경로가 반드시 하나는 존재
-    2-3. 임의의 두 쌍 사이의 동영상의 USADO를 그 경로의 모든 연결들의 USADO 중 최소값으로 함.
-4. 값 K를 정해서, USADO가 K이상인 모든 동영상이 추천되고, K가 입력되었을 때의 추천될 영상의 개수를 구하기
-'''
-global n
+from collections import deque
+
+n = 0
 
 
 def input_func():
     global n
     n, q = map(int, input().split())
-    usado = [[0 for _ in range(n)] for _ in range(n)]
+    usado = [[] for _ in range(n)]
 
     for _ in range(n - 1):
         input_p, input_q, input_r = map(int, input().split())
-        usado[input_p - 1][input_q - 1] = input_r
-        usado[input_q - 1][input_p - 1] = input_r
+        usado[input_p - 1].append((input_q - 1, input_r))
+        usado[input_q - 1].append((input_p - 1, input_r))
 
     questions = []
     for _ in range(q):
@@ -25,31 +19,27 @@ def input_func():
     return usado, questions
 
 
-def get_minimum_usado(usado, i, j):
-    for k in range(n):
-        if usado[i][k] > 0 and usado[k][j] > 0:
-            min_usado = min(usado[i][k], usado[k][j])
-            usado[i][j] = min_usado
-            usado[j][i] = min_usado
-
-
-def update_usado(usado, row_index):
-    # usado값이 정해지지 않은 값에 대해서 usado를 구함
-    for j in range(n):
-        if row_index == j:
-            continue
-        if usado[row_index][j] == 0:
-            get_minimum_usado(usado, row_index, j)
+def bfs(start, min_usado, visited, usado):
+    count = 0
+    stack = deque()
+    stack.append(start)
+    while stack:
+        cur_node = stack.popleft()
+        for next_node, cur_usado in usado[cur_node]:
+            if not visited[next_node] and cur_usado >= min_usado:
+                visited[next_node] = True
+                count += 1
+                stack.append(next_node)
+    return count
 
 
 def main():
     usado, questions = input_func()
     for k, v in questions:
-        update_usado(usado, v)
-        print(f"k: {k}, v : {v}")
-        print(usado)
-        cur_num_usado = usado[v - 1]
-        print(sum(1 for num in cur_num_usado if num >= k))
+        visited = [False] * n
+        visited[v - 1] = True
+        result = bfs(v - 1, k, visited, usado)
+        print(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## [MooTube (Silver) ](https://www.acmicpc.net/problem/15591)

#### 소요시간
- 약 1시간

#### 간단 풀이 방식
- 인접리스트와 stack을 활용해서 풀이

#### 헤맸던 부분
1. 인접행렬 vs 인접리스트
- 처음 문제를 풀었을 당시 모든 정점들이 하나 이상의 노드와 연결됬다는 것을 보고, 플로이드-워셜 알고리즘과 인접행렬을 활용하였음.
- 하지만 시간초과가 났고, 모든 노드의 쌍을 저장하는 것이 원인이라 판단. 
- 또 인접행렬을 활용할 경우 경로상에서 min USADO인 K를 반영하지 못하는 경우가 존재할 수 있기에 인접리스트 활용
2. DFS vs BFS
- DFS로 구현하였으나, recursion에러가 발생함.
- recursion limit을 푸는 코드를 추가 했더니 시간초과가 남.
- 위를 해결하기 위해 재귀함수 대신, stack을 활용한 BFS 구조로 수정.
#### Pseudo Code
```
def bfs(start, min_usado, visited, usado):
    count = 0
    stack = deque()
    stack.append(start)
    while stack:
        cur_node = stack.popleft()
        for next_node, cur_usado in usado[cur_node]:
            if not visited[next_node] and cur_usado >= min_usado:
                visited[next_node] = True
                count += 1
                stack.append(next_node)
    return count
```

#### 시간복잡도
- $O(q\cdot n) 
*  q : 질문의 개수, n : 노드의 개수

#### 소요시간 및 메모리 (**PyPy3 기준**, PyPy3가 사용되지 않았다면 괄호를 제거합니다.)
- 메모리 : 35848 KB
- 소요시간 : 3520 ms
