### PR TITLE
JUN WEEK4 : 로봇 조종하기

### DIFF
--- a/Baekjoon/ControlRobot_2169.py
+++ b/Baekjoon/ControlRobot_2169.py
@@ -1,0 +1,55 @@
+n, m = 0, 0
+max_value = 0
+
+
+def input_func():
+    global n, m
+    n, m = map(int, input().split())
+
+    mars_map = []
+    for _ in range(n):
+        mars_map.append(list(map(int, input().split())))
+
+    return mars_map
+
+
+def calc_cost(mars_map, costs):
+    # 첫번째 행은 오른쪽으로만 이동 가능하기 때문에 누적합으로 초기화
+    costs[0][0] = mars_map[0][0]
+    for j in range(1, m):
+        costs[0][j] = costs[0][j - 1] + mars_map[0][j]
+
+    for i in range(1, n):
+        left_dp = [0 for _ in range(m)]
+        right_dp = [0 for _ in range(m)]
+
+        # 현재 행의 각 칸으로 오기 위한 두가지 방향을 고려 (왼->오 / 오->왼)
+        # 왼쪽으로 이동하는 경우의 첫열, 오른쪽으로 이동하는 경우의 마지막열을 초기화
+        left_dp[0] = costs[i - 1][0] + mars_map[i][0]
+        right_dp[-1] = costs[i - 1][-1] + mars_map[i][-1]
+
+        # 왼쪽으로만 이동하는 경우
+        for j in range(1, m):
+            left_dp[j] = max(costs[i - 1][j], left_dp[j - 1]) + mars_map[i][j]
+
+        # 오른쪽으로만 이동하는 경우
+        for j in range(m - 2, -1, -1):
+            right_dp[j] = max(costs[i - 1][j], right_dp[j + 1]) + mars_map[i][j]
+
+        # 두 방향 중 더 큰값으로 갱신
+        for j in range(m):
+            costs[i][j] = max(right_dp[j], left_dp[j])
+
+    return costs[-1][-1]
+
+
+def main():
+    mars_map = input_func()
+    costs = [[0 for _ in range(m)] for _ in range(n)]
+    costs[0][0] = mars_map[0][0]
+    answer = calc_cost(mars_map, costs)
+    print(answer)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## [로봇 조종하기](https://www.acmicpc.net/problem/2169)

#### 소요시간
- 약 1시간

#### 간단 풀이 방식
- 왼쪽 -> 오른쪽 순으로 탐색하며 누적 최대값을 저장(`left_dp`)
- 오른쪽 -> 왼쪽 순으로 탐색하며 누적 최대값을 저장(`right_dp`)
- 마지막으로 두 결과 중 더 큰 값을 최종 `costs` 배열에 저장

#### 헤맸던 부분
- `left_dp`와 `right_dp` 의 값을 한 행에서 혼합해서 사용해도 되는지 이해가 안돼서 헤맴.
- 이해하고 나니 위로는 이동할 수 없고, 방문한 곳은 다시 방문할 수 없다는 조건 때문에 가능하였음.
- 만약 위로도 이동할 수 있었더라면 bfs, dfs와 같은 방법을 활용해야만 함.

#### Pseudo Code
```
def calc_cost(mars_map, costs):
    costs[0][0] = mars_map[0][0]
    for j in range(1, m):
        costs[0][j] = costs[0][j - 1] + mars_map[0][j]

    for i in range(1, n):
        left_dp = [0 for _ in range(m)]
        right_dp = [0 for _ in range(m)]

        left_dp[0] = costs[i - 1][0] + mars_map[i][0]
        right_dp[-1] = costs[i - 1][-1] + mars_map[i][-1]

        for j in range(1, m):
            left_dp[j] = max(costs[i - 1][j], left_dp[j - 1]) + mars_map[i][j]

        for j in range(m - 2, -1, -1):
            right_dp[j] = max(costs[i - 1][j], right_dp[j + 1]) + mars_map[i][j]

        for j in range(m):
            costs[i][j] = max(right_dp[j], left_dp[j])

    return costs[-1][-1]
```

#### 시간복잡도
- $O(N \cdot M)$
* N과 M은 입력받은 지도의 행,열의 크기

#### 소요시간 및 메모리
- 메모리 : 95764 KB
- 소요시간 : 712 ms
